### PR TITLE
start adding mobile styles (bankForm), create and use TitleText Atom, and more

### DIFF
--- a/packages/example-ui/public/index.html
+++ b/packages/example-ui/public/index.html
@@ -23,13 +23,15 @@
     />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@4.0.0/dist/webcomponents/webcomponents.css" />
     <style>
+      /* Taken from https://storybook.justifi.ai */
       :root {
         --jfi-layout-padding: 0;
         --jfi-layout-form-control-spacing-x: .5rem;
         --jfi-layout-form-control-spacing-y: 1rem;
-        --jfi-form-label-font-weight: 700;
+        --jfi-form-label-font-weight: 400;
         --jfi-form-label-font-family: sans-serif;
         --jfi-form-label-margin: 0 0 .5rem 0;
+        --jfi-form-label-color: #5E5E66;
         --jfi-form-control-background-color: #F4F4F6;
         --jfi-form-control-background-color-hover: #EEEEF5;
         --jfi-form-control-border-color: rgba(0, 0, 0, 0.42);

--- a/packages/example-ui/src/App.tsx
+++ b/packages/example-ui/src/App.tsx
@@ -5,7 +5,7 @@ import Onboarding from "./components/features/Onboarding";
 import Payments from "./components/features/Payments";
 import Events from "./components/features/Events";
 import Checkout from "./components/features/Checkout";
-import { CssBaseline } from "@mui/material";
+import { Box, CssBaseline, Skeleton, Typography } from "@mui/material";
 import BankCheckout from "./components/features/BankCheckout";
 import HostedCheckout from "./components/features/HostedCheckout";
 import CheckoutSuccess from "./components/features/HostedCheckoutForm/CheckoutSuccess";
@@ -15,7 +15,21 @@ import { useAuth0 } from '@auth0/auth0-react';
 export default function App() {
   const { isAuthenticated, isLoading, loginWithRedirect } = useAuth0();
   if(isLoading) {
-    return(<div>Loading...</div>);
+    return(
+      <Box sx={{
+        width: '100vw',
+        height: '100vh',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        flexDirection: 'column',
+        gap: '20px',
+        color: 'rgba(0, 0, 0, 0.25)'
+      }}>
+        <Skeleton variant="circular" width={128} height={128}></Skeleton>
+        <Typography variant="h4">Loading</Typography>
+      </Box>
+    );
   }
 
   if (isAuthenticated) {

--- a/packages/example-ui/src/components/common/BankCheckout/BankForm.tsx
+++ b/packages/example-ui/src/components/common/BankCheckout/BankForm.tsx
@@ -16,13 +16,13 @@ import {
   InputLabel
 } from "@mui/material";
 import { JustifiBankAccountForm } from '@justifi/react-components';
-import { makeStyles } from "@mui/styles";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { bankCheckoutFormSchema } from '../makeSchemas';
 import JustiFiPalette from "../JustiFiPallete";
 import { getConfig } from "../../../config";
 import { PaymentsApi } from "../../../api/Payment";
 import { formatCentsToDollars } from "../utils";
+import { TitleText } from "../atoms";
 
 const clientId = process.env.REACT_APP_JUSTIFI_CLIENT_ID || getConfig().clientId;
 
@@ -32,29 +32,6 @@ export interface CreatePaymentParams {
   sellerAccountId: string;
   sellerSafeName: string;
 }
-
-const contentOffset = "24px";
-const useStyles = makeStyles(
-  (theme: any) => ({
-    layout: {
-      display: "flex",
-      flexDirection: "column",
-      height: "100%",
-      maxHeight: "100%",
-      overflowY: "scroll",
-    },
-    layoutContent: {
-      flex: 1,
-      marginTop: `${contentOffset}`,
-      minHeight: 0,
-      maxHeight: `calc(100% + ${contentOffset})`,
-      [theme.breakpoints.up("2048")]: {
-        maxWidth: `calc(100vw - '30vm' - '256px')`,
-      },
-    },
-  }),
-  { index: 1 }
-);
 
 function BankForm(props: { params: CreatePaymentParams }) {
   const Payments = PaymentsApi();
@@ -82,8 +59,6 @@ function BankForm(props: { params: CreatePaymentParams }) {
       setEnableSubmit(true);
     }
   }, [errors, formState, showPaymentMethodErrors])
-  
-  const classes = useStyles();
 
   async function onSubmit(formValues: any) {
     setShowPaymentMethodErrors(true);
@@ -117,149 +92,132 @@ function BankForm(props: { params: CreatePaymentParams }) {
   }
 
   return (
-    <div className={classes.layout}>
-      <div className={classes.layoutContent}>
-        <Grid container sx={{
-          justifyContent: "center",
+    <Grid container sx={{
+      marginTop: {xs: '20px', md: '0'},
+      justifyContent: "center",
+      borderRadius: '5px',
+    }}>
+      <Grid item
+        md={'auto'}
+        sx={{
+          width: '100%',
+          maxWidth: '600px',
+          backgroundColor: "white",
+          padding: 4,
           borderRadius: '5px',
-        }}>
-          <Box
-            sx={{
-              backgroundColor: "white",
-              padding: 4,
-              borderRadius: '5px',
-              transition: '0.2s ease-in-out filter',
-            }}
-          >
-            <Card>
-              <form aria-label="refund form" onSubmit={handleSubmit(onSubmit, onSubmit)}>
-                <CardContent>
-                  <Box
-                    sx={{
-                      display: "flex",
-                      flexDirection: "column",
-                      alignItems: "center",
-                    }}
+          transition: '0.2s ease-in-out filter',
+        }}
+      >
+        <Card>
+          <form aria-label="refund form" onSubmit={handleSubmit(onSubmit, onSubmit)}>
+            <CardContent>
+              <Box
+                sx={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                }}
+              >
+                <Typography
+                  sx={{
+                    fontSize: "20px",
+                    color: "#004C4D",
+                    fontWeight: "bold",
+                    padding: "0",
+                  }}
+                >
+                  {params.sellerSafeName}
+                </Typography>
+                <TitleText>
+                  {formatCentsToDollars(params.amount || 0.0)}
+                </TitleText>
+                {/* TODO: convert to Subtitle component */}
+                <Typography
+                  variant="h5"
+                  sx={{
+                    fontSize: "16px",
+                    color: JustiFiPalette.grey[700],
+                    fontWeight: 400,
+                    padding: "0",
+                    marginBottom: "12px"
+                  }}
+                >
+                  {params.description}{" "}
+                </Typography>
+              </Box>
+              <Box>
+                <JustifiBankAccountForm 
+                  iframeOrigin={`${process.env.REACT_APP_JUSTIFI_COMPS_URL || 'https://js.justifi.ai'}/v2`}
+                  ref={bankFormRef}
+                />
+              </Box>
+              <Box>
+                <TextField
+                  fullWidth
+                  id="name"
+                  label="Account Owner Name"
+                  type="text"
+                  variant="filled"
+                  margin="normal"
+                  {...register("name")}
+                />
+                {<FormHelperText error>{errors.name?.message as string}</FormHelperText>}
+              </Box>
+              <Box>
+                <FormControl
+                  variant="filled"
+                  fullWidth
+                  sx={{
+                    margin: '10px 0'
+                  }}
+                >
+                  <InputLabel htmlFor="account_owner_type">Select an account owner type</InputLabel>
+                  <Select
+                    {...register("account_owner_type")}
+                    id="account_owner_type"
+                    defaultValue=""
                   >
-                    <Typography
-                      sx={{
-                        fontSize: "20px",
-                        color: "#004C4D",
-                        fontWeight: "bold",
-                        padding: "0",
-                      }}
-                    >
-                      {params.sellerSafeName}
-                    </Typography>
-                    <Typography
-                      sx={{
-                        fontSize: "34px",
-                        color: "#004C4D",
-                        fontWeight: "bold",
-                        padding: "0",
-                      }}
-                    >
-                      {formatCentsToDollars(params.amount || 0.0)}
-                    </Typography>
-                    <Typography
-                      variant="h5"
-                      sx={{
-                        fontSize: "16px",
-                        color: JustiFiPalette.grey[700],
-                        fontWeight: 400,
-                        padding: "0",
-                      }}
-                    >
-                      {params.description}{" "}
-                    </Typography>
-                  </Box>
-                  <Box sx={{ marginTop: "32px" }}>
-                    <Typography
-                      variant="h5"
-                      sx={{
-                        fontSize: "16px",
-                        color: JustiFiPalette.grey[700],
-                        fontWeight: 400,
-                      }}
-                    >
-                      Payment Method
-                    </Typography>
-                  </Box>
-                  <Box>
-                    <JustifiBankAccountForm 
-                      iframeOrigin={`${process.env.REACT_APP_JUSTIFI_COMPS_URL || 'https://js.justifi.ai'}/v2`}
-                      ref={bankFormRef}
-                    />
-                  </Box>
-                  <Box>
-                    <TextField
-                      fullWidth
-                      id="name"
-                      label="Account Owner Name"
-                      type="text"
-                      variant="filled"
-                      margin="normal"
-                      {...register("name")}
-                    />
-                    {<FormHelperText error>{errors.name?.message as string}</FormHelperText>}
-                  </Box>
-                  <Box>
-                    <FormControl
-                      variant="filled"
-                      fullWidth
-                      sx={{
-                        margin: '10px 0'
-                      }}
-                    >
-                      <InputLabel htmlFor="account_owner_type">Select an account owner type</InputLabel>
-                      <Select
-                        {...register("account_owner_type")}
-                        id="account_owner_type"
-                        defaultValue=""
-                      >
-                        <MenuItem value="individual">Individual</MenuItem>
-                        <MenuItem value="company">Company</MenuItem>
-                      </Select>
-                    </FormControl>
-                    {<FormHelperText error>{errors.account_owner_type?.message as string}</FormHelperText>}
-                  </Box>
-                  <Box>
-                    <FormControl
-                      variant="filled"
-                      fullWidth
-                      sx={{
-                        margin: '10px 0'
-                      }}
-                    >
-                      <InputLabel htmlFor="account_type">Select an account type</InputLabel>
-                      <Select
-                        id="account_type"
-                        defaultValue=""
-                        {...register("account_type")}
-                      >
-                        <MenuItem value="checking">Checking</MenuItem>
-                        <MenuItem value="savings">Savings</MenuItem>
-                      </Select>
-                    </FormControl>
-                    {<FormHelperText error>{errors.account_type?.message as string}</FormHelperText>}
-                  </Box>
-                </CardContent>
-                <CardActions sx={{ padding: "0", marginTop: "30px" }}>
-                  <Button
-                    disabled={!enableSubmit || submitting}
-                    type="submit"
-                    variant="contained"
-                    fullWidth
+                    <MenuItem value="individual">Individual</MenuItem>
+                    <MenuItem value="company">Company</MenuItem>
+                  </Select>
+                </FormControl>
+                {<FormHelperText error>{errors.account_owner_type?.message as string}</FormHelperText>}
+              </Box>
+              <Box>
+                <FormControl
+                  variant="filled"
+                  fullWidth
+                  sx={{
+                    margin: '10px 0'
+                  }}
+                >
+                  <InputLabel htmlFor="account_type">Select an account type</InputLabel>
+                  <Select
+                    id="account_type"
+                    defaultValue=""
+                    {...register("account_type")}
                   >
-                    Authorize & Capture Payment
-                  </Button>
-                </CardActions>
-              </form>
-            </Card>
-          </Box>
-        </Grid>
-      </div>
-    </div>
+                    <MenuItem value="checking">Checking</MenuItem>
+                    <MenuItem value="savings">Savings</MenuItem>
+                  </Select>
+                </FormControl>
+                {<FormHelperText error>{errors.account_type?.message as string}</FormHelperText>}
+              </Box>
+            </CardContent>
+            <CardActions sx={{ padding: "0", marginTop: "30px" }}>
+              <Button
+                disabled={!enableSubmit || submitting}
+                type="submit"
+                variant="contained"
+                fullWidth
+              >
+                Authorize & Capture Payment
+              </Button>
+            </CardActions>
+          </form>
+        </Card>
+      </Grid>
+    </Grid>
   );
 }
 

--- a/packages/example-ui/src/components/common/Checkout/CardFormComponent.tsx
+++ b/packages/example-ui/src/components/common/Checkout/CardFormComponent.tsx
@@ -20,6 +20,7 @@ import JustiFiPalette from "../JustiFiPallete";
 import { getConfig } from "../../../config";
 import { PaymentsApi } from "../../../api/Payment";
 import { formatCentsToDollars } from "../utils";
+import { TitleText } from "../atoms";
 
 const clientId = process.env.REACT_APP_JUSTIFI_CLIENT_ID || getConfig().clientId;
 export interface CreatePaymentParams {
@@ -115,6 +116,11 @@ function CardFormComponent(props: { params: CreatePaymentParams }) {
 
   return (
     <div className={classes.layout}>
+      <style>
+        {`:root {
+          --jfi-form-control-padding: .5rem 0;
+        }`}
+      </style>
       <div className={classes.layoutContent}>
         <Grid container sx={{
           justifyContent: "center",
@@ -154,16 +160,9 @@ function CardFormComponent(props: { params: CreatePaymentParams }) {
                     >
                       {params.sellerSafeName}
                     </Typography>
-                    <Typography
-                      sx={{
-                        fontSize: "34px",
-                        color: "#004C4D",
-                        fontWeight: "bold",
-                        padding: "0",
-                      }}
-                    >
+                    <TitleText>
                       {formatCentsToDollars(params.amount || 0.0)}
-                    </Typography>
+                    </TitleText>
                     <Typography
                       variant="h5"
                       sx={{

--- a/packages/example-ui/src/components/common/Checkout/CreatePaymentForm.tsx
+++ b/packages/example-ui/src/components/common/Checkout/CreatePaymentForm.tsx
@@ -15,6 +15,7 @@ import JustiFiPalette from "../JustiFiPallete";
 import { paymentFormSchema } from "../makeSchemas";
 import { makeStyles } from "@mui/styles";
 import SelectSeller from "../../features/SelectSeller";
+import { TitleText } from "../atoms";
 
 const useStyles = makeStyles(() => ({
   content: {
@@ -93,25 +94,18 @@ const CreatePaymentForm = (
       <Card variant="outlined" className={classes.content}>
         <form aria-label="refund form" onSubmit={handleSubmit(extendedSubmitHandler)}>
           <CardContent sx={{ padding: "0" }}>
-            <Typography
-              sx={{
-                fontSize: "34px",
-                color: "#004C4D",
-                fontWeight: 700,
-                padding: "0",
-              }}
-            >
+            <TitleText>
               {title ? title :
                 'Create a Payment'
               }
-            </Typography>
+            </TitleText>
             <SubheaderText variant="h5">
               Configure the settings of the payment you’d like to send to the
               checkout.
             </SubheaderText>
             
             {!seller ? 
-              <SelectSeller noForm submitOnChange handleSubmit={onSellerSelected} />
+              <SelectSeller noForm submitOnChange handleSubmit={onSellerSelected} height={56}/>
             :
               null
             }

--- a/packages/example-ui/src/components/common/Header.tsx
+++ b/packages/example-ui/src/components/common/Header.tsx
@@ -2,6 +2,7 @@ import { FunctionComponent } from "react";
 import { Grid, Divider, Typography, styled } from "@mui/material";
 import { Variant } from "@mui/material/styles/createTypography";
 import JustiFiPalette from "./JustiFiPallete";
+import { TitleText } from "./atoms";
 
 interface HeaderProps {
   header: string | JSX.Element | JSX.Element[];
@@ -55,12 +56,9 @@ const Header: FunctionComponent<React.PropsWithChildren<HeaderProps>> = (
     <FullWidthHeader>
       <Grid container spacing={2} wrap="nowrap">
         <Grid item xs>
-          <Typography
-            variant={fontVariants[variant].header}
-            sx={{ fontSize: "34px", color: "#004C4D" }}
-          >
+          <TitleText>
             <HeaderText>{header}</HeaderText>
-          </Typography>
+          </TitleText>
 
           {subheader && (
             <SubheaderText variant={fontVariants[variant].subheader}>

--- a/packages/example-ui/src/components/common/atoms/index.tsx
+++ b/packages/example-ui/src/components/common/atoms/index.tsx
@@ -1,0 +1,15 @@
+import { Typography } from "@mui/material";
+import { ReactElement } from "react";
+
+const TitleText = ({ children }: { children: ReactElement | string }) => <Typography
+  sx={{
+    fontSize: "34px",
+    color: "#004C4D",
+    fontWeight: "bold",
+    padding: "0",
+  }}
+>{children}</Typography>
+
+export {
+  TitleText
+};

--- a/packages/example-ui/src/components/features/BankCheckout.tsx
+++ b/packages/example-ui/src/components/features/BankCheckout.tsx
@@ -10,6 +10,7 @@ import AppTopBar from "../common/AppTopBar";
 import BankForm from "../common/BankCheckout/BankForm";
 import SelectSeller from "./SelectSeller";
 import { FormEvent, useState } from "react";
+import { TitleText } from "../common/atoms";
 
 const HeaderText = styled("span")({
   display: "flex",
@@ -41,20 +42,17 @@ const BankCheckout = () => {
       <AppTopBar />
       <Box component="main">
         <Toolbar />
-        <Grid container sx={{ padding: "32px" }}>
-          <Grid>
-            <Typography
-              variant="h4"
-              sx={{ fontSize: "34px", color: "#004C4D", fontWeight: 700 }}
-            >
-              <HeaderText>Bank Account Component</HeaderText>
-            </Typography>
-            <SubheaderText variant="h5" margin="15px 0">
-              This is an example of the usage of the Bank Account Web Component. The platform can use
-              their own fields to collect any additional info that's relevant to
-              them, while the iframed bank account form will send the payment method
-              info to JustiFi, keeping the platform free of PCI scope.
-            </SubheaderText>
+        <Grid container columns={12} sx={{ padding: "32px" }}>
+          <TitleText>
+            <HeaderText>Bank Account Component</HeaderText>
+          </TitleText>
+          <SubheaderText variant="h5" margin="15px 0">
+            This is an example of the usage of the Bank Account Web Component. The platform can use
+            their own fields to collect any additional info that's relevant to
+            them, while the iframed bank account form will send the payment method
+            info to JustiFi, keeping the platform free of PCI scope.
+          </SubheaderText>
+          <Grid item xs={12} md={6}>
             <SelectSeller
               submitOnChange
               handleSubmit={
@@ -67,6 +65,8 @@ const BankCheckout = () => {
               }
             }
             />
+          </Grid>
+          <Grid item xs={12} md={6}>
             <BankForm params={{
               amount: 1000,
               description: `test payment for: ${currentSeller.selectedSellerSafeName}`,

--- a/packages/example-ui/src/components/features/Checkout.tsx
+++ b/packages/example-ui/src/components/features/Checkout.tsx
@@ -12,6 +12,7 @@ import JustiFiPalette from "../common/JustiFiPallete";
 import AppTopBar from "../common/AppTopBar";
 import CreatePaymentForm from "../common/Checkout/CreatePaymentForm";
 import CardFormComponent from "../common/Checkout/CardFormComponent";
+import { TitleText } from "../common/atoms";
 
 const HeaderText = styled("span")({
   display: "flex",
@@ -56,12 +57,9 @@ const Checkout = () => {
         <Toolbar />
         <Grid container sx={{ padding: "32px" }}>
           <Grid>
-            <Typography
-              variant="h4"
-              sx={{ fontSize: "34px", color: "#004C4D", fontWeight: 700 }}
-            >
+            <TitleText>
               <HeaderText>Card Form Component</HeaderText>
-            </Typography>
+            </TitleText>
             <SubheaderText variant="h5">
               This is an example of the platform using the JustiFi Card Form
               component inside of their checkout page. The platform can use

--- a/packages/example-ui/src/components/features/CreateSeller/CreateSellerForm.tsx
+++ b/packages/example-ui/src/components/features/CreateSeller/CreateSellerForm.tsx
@@ -14,6 +14,7 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import JustiFiPalette from "../../common/JustiFiPallete";
 import { makeStyles } from "@mui/styles";
 import SellerFormSchema from "./CreateSellerFormSchema";
+import { TitleText } from "../../common/atoms";
 
 const useStyles = makeStyles(() => ({
   content: {
@@ -86,16 +87,9 @@ const CreateSellerForm = (
           onSubmit={handleSubmit(onSubmit, onError)}
         >
           <CardContent sx={{ padding: "0" }}>
-            <Typography
-              sx={{
-                fontSize: "34px",
-                color: "#004C4D",
-                fontWeight: "bold",
-                padding: "0",
-              }}
-            >
+            <TitleText>
               Create a Seller
-            </Typography>
+            </TitleText>
             <SubheaderText variant="h5">
               {
                 "Provide the name of the sub account you'd like to send to hosted onboarding."

--- a/packages/example-ui/src/components/features/Events.tsx
+++ b/packages/example-ui/src/components/features/Events.tsx
@@ -6,6 +6,7 @@ import JustiFiPalette from "../common/JustiFiPallete";
 import { Event, listRecentEvents } from "../../api/Events";
 import EventsTableHeaderRow from "../common/Events/EventsTableHeaderRow";
 import EventsTableRow from "../common/Events/EventsTableRow";
+import { TitleText } from "../common/atoms";
 
 const HeaderText = styled("span")({
   display: "flex",
@@ -48,9 +49,9 @@ const Events = () => {
         sx={{ height: 155, backgroundColor: "white", padding: "32px" }}
       >
         <Grid item xs>
-          <Typography variant="h4" sx={{ fontSize: "34px", color: "#004C4D" }}>
+          <TitleText>
             <HeaderText>Received Events</HeaderText>
-          </Typography>
+          </TitleText>
           <SubheaderText variant="h5">
             These are all the events the platform has received from JustiFi, based on the
             event publishers the platform created

--- a/packages/example-ui/src/components/features/HostedCheckout.tsx
+++ b/packages/example-ui/src/components/features/HostedCheckout.tsx
@@ -9,6 +9,7 @@ import {
 import JustiFiPalette from "../common/JustiFiPallete";
 import AppTopBar from "../common/AppTopBar";
 import HostedCheckoutComponent from "./HostedCheckoutForm";
+import { TitleText } from "../common/atoms";
 
 const HeaderText = styled("span")({
   display: "flex",
@@ -36,12 +37,9 @@ const HostedCheckout = () => {
         <Toolbar />
         <Grid container sx={{ padding: "32px" }}>
           <Grid>
-            <Typography
-              variant="h4"
-              sx={{ fontSize: "34px", color: "#004C4D", fontWeight: 700 }}
-            >
+            <TitleText>
               <HeaderText>Card Form Component</HeaderText>
-            </Typography>
+            </TitleText>
             <SubheaderText variant="h5">
               This is an example of the platform using the JustiFi Hosted Checkout.
             </SubheaderText>

--- a/packages/example-ui/src/components/features/HostedCheckoutForm/CheckoutSuccess.tsx
+++ b/packages/example-ui/src/components/features/HostedCheckoutForm/CheckoutSuccess.tsx
@@ -11,6 +11,7 @@ import {
 import AppTopBar from "../../common/AppTopBar";
 import JustiFiPalette from "../../common/JustiFiPallete";
 import { Link } from "react-router-dom";
+import { TitleText } from "../../common/atoms";
 
 const HeaderText = styled("span")({
   display: "flex",
@@ -38,12 +39,9 @@ const CheckoutSuccess = () => {
         <Toolbar />
         <Grid container sx={{ padding: "32px" }}>
           <Grid>
-            <Typography
-              variant="h4"
-              sx={{ fontSize: "34px", color: "#004C4D", fontWeight: 700 }}
-            >
+            <TitleText>
               <HeaderText>Hosted Checkout Success</HeaderText>
-            </Typography>
+            </TitleText>
             <SubheaderText variant="h5">
               This is an example of a page to redirect to after payment success when using the Hosted Checkout.
               This can be configured through the 'after_payment_url' property when creating the Checkout Session.

--- a/packages/example-ui/src/components/features/PaymentForm.tsx
+++ b/packages/example-ui/src/components/features/PaymentForm.tsx
@@ -9,6 +9,7 @@ import {
 import JustiFiPalette from "../common/JustiFiPallete";
 import AppTopBar from "../common/AppTopBar";
 import PaymentFormComponent from "../common/PaymentForm";
+import { TitleText } from "../common/atoms";
 
 const HeaderText = styled("span")({
   display: "flex",
@@ -36,12 +37,9 @@ const PaymentFormCheckout = () => {
         <Toolbar />
         <Grid container sx={{ padding: "32px" }}>
           <Grid>
-            <Typography
-              variant="h4"
-              sx={{ fontSize: "34px", color: "#004C4D", fontWeight: 700 }}
-            >
+            <TitleText>
               <HeaderText>Payment Form Component</HeaderText>
-            </Typography>
+            </TitleText>
             <SubheaderText variant="h5">
               This is an example of the platform using the JustiFi PaymentForm component. This component includes everything needed to properly create a payment method.
             </SubheaderText>

--- a/packages/example-ui/src/components/features/Payments.tsx
+++ b/packages/example-ui/src/components/features/Payments.tsx
@@ -10,6 +10,7 @@ import { Payment } from "../../api/Payment";
 import PaymentsTableRow from "../common/Payments/PaymentsTableRow";
 import PaymentsTableHeaderRow from "../common/Payments/PaymentsTableHeaderRow";
 import { HttpMethod, IApiResponse, IPagination, Api } from "../../api/Api";
+import { TitleText } from "../common/atoms";
 
 const HeaderText = styled("span")({
   display: "flex",
@@ -56,9 +57,9 @@ const Payments = () => {
         sx={{ height: 155, backgroundColor: "white", padding: "32px" }}
       >
         <Grid item xs>
-          <Typography variant="h4" sx={{ fontSize: "34px", color: "#004C4D" }}>
+          <TitleText>
             <HeaderText>Payments</HeaderText>
-          </Typography>
+          </TitleText>
           <SubheaderText variant="h5">
             These are all the payments the sub account has processed through JustiFi.
             The platform can hit our API to display this data in their UI for

--- a/packages/example-ui/src/components/features/SelectSeller/index.tsx
+++ b/packages/example-ui/src/components/features/SelectSeller/index.tsx
@@ -3,6 +3,7 @@ import { Alert, Box, Card, CardActions, CardContent, FormControl, Grid, InputLab
 import { Sellers, ISellerList } from "../../../api/Seller";
 import { IApiResponse, IErrorObject, IServerError } from "../../../api/Api";
 import { useNavigate } from "react-router";
+import { TitleText } from "../../common/atoms";
 
 const SelectSellerError = (props: { error: IErrorObject | IServerError }) => {
   const { error } = props;
@@ -26,9 +27,9 @@ const SelectSellerError = (props: { error: IErrorObject | IServerError }) => {
 };
 
 const SelectSeller = (
-  { handleSubmit, maxWidth, actions, submitOnChange, noForm }: {
+  { handleSubmit, maxWidth, actions, submitOnChange, noForm, height }: {
     handleSubmit?: Function, maxWidth?: string, actions?: { element: ReactElement },
-    submitOnChange?: boolean, noForm?: boolean
+    submitOnChange?: boolean, noForm?: boolean, height?: number | string
   }) => {
   const [url, setUrl] = useState<string>("");
   const [enabled, setEnabled] = useState<boolean>(false);
@@ -94,7 +95,7 @@ const SelectSeller = (
         maxWidth: maxWidth || '600px'
       }}>
         {loading ? (
-        <Skeleton variant="rectangular" height={200}/>
+        <Skeleton variant="rectangular" height={height || (actions ? 235 : 173)}/>
         ) : (
           <Card
             variant={!noForm ? "outlined" : undefined}
@@ -110,16 +111,9 @@ const SelectSeller = (
             <FormWrap noForm={noForm}>
               <CardContent sx={{ padding: "0 !important" }}>
                 {!noForm && 
-                  <Typography
-                    sx={{
-                      fontSize: "34px",
-                      color: "#004C4D",
-                      fontWeight: "bold",
-                      padding: "0",
-                    }}
-                  >
+                  <TitleText>
                     Select a Sub Account
-                  </Typography>
+                  </TitleText>
                 }
                 <FormControl fullWidth>
                   <InputLabel variant="filled" id="subaccount-selector">Select a Sub Account</InputLabel>


### PR DESCRIPTION
- Simplify some styling and add responsive styling for bankForm.
- Create and reuse TitleText atomic component.
- Fix styling for bankForm component.
- Improve Loading screen to be more than just a text.
- Fix height of some skeletons to avoid content jump on load.

Screenshots:
<img width="1096" alt="image" src="https://github.com/justifi-tech/example-app/assets/10523683/0aeba340-b7b2-41d6-afe3-745d17572d0f">
<img width="1176" alt="image" src="https://github.com/justifi-tech/example-app/assets/10523683/1ba8d675-0691-4a75-a8b0-4bec0836d74e">
<img width="1260" alt="image" src="https://github.com/justifi-tech/example-app/assets/10523683/fb57a239-41e3-43db-9ddf-07f4ef1f0732">
